### PR TITLE
`observedAttributes` should allow kebab-case properties.

### DIFF
--- a/.changeset/thirty-seas-dream.md
+++ b/.changeset/thirty-seas-dream.md
@@ -1,0 +1,6 @@
+---
+"@pionjs/pion": minor
+---
+
+`observedAttributes` should allow kebab-case properties.
+For example if there is a property called `myProp` allow setting `observedAttributes` to `['my-prop']`;


### PR DESCRIPTION
e.g.: if there is a property called `myProp` allow setting `observedAttributes` to `['my-prop']`;
