### PR TITLE
feat(use-ref): adjust type definition

### DIFF
--- a/.changeset/khaki-seahorses-rhyme.md
+++ b/.changeset/khaki-seahorses-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@pionjs/pion": minor
+---
+
+Allow omitting initialValue from useRef.

--- a/src/use-ref.ts
+++ b/src/use-ref.ts
@@ -1,17 +1,22 @@
 import { useMemo } from "./use-memo";
 
+interface Ref<T> {
+  current: T;
+}
+
 /**
  * @function
  * @template T
  * @param   {T} initialValue
  * @return  {{ current: T }} Ref
  */
-const useRef = <T>(initialValue: T) =>
-  useMemo(
+export function useRef<T>(): Ref<T | undefined>;
+export function useRef<T>(initialValue: T): Ref<T>;
+export function useRef<T>(initialValue?: T): Ref<T | undefined> {
+  return useMemo(
     () => ({
       current: initialValue,
     }),
     []
   );
-
-export { useRef };
+}


### PR DESCRIPTION
Adjust the type definition of `useRef` allowing omitting the value
param.
