### PR TITLE
Make context providers transparent to the layout

### DIFF
--- a/.changeset/forty-waves-wink.md
+++ b/.changeset/forty-waves-wink.md
@@ -1,0 +1,5 @@
+---
+"@pionjs/pion": patch
+---
+
+Make context providers transparent to the layout

--- a/src/create-context.ts
+++ b/src/create-context.ts
@@ -34,6 +34,9 @@ function makeContext(component: ComponentCreator): Creator {
 
         constructor() {
           super();
+
+          this.style.display = "contents";
+
           this.listeners = new Set();
 
           this.addEventListener(contextEvent, this);


### PR DESCRIPTION
Context provider elements have `display: block` by default, which can
cause trouble with the layout when wrapping existing code in a provider.

This change makes it so that provider elements are irrelevant to the
layout, as they should be.
