### PR TITLE
Fix: Reattaching an element does not re-run the effects

### DIFF
--- a/.changeset/hungry-files-shout.md
+++ b/.changeset/hungry-files-shout.md
@@ -1,0 +1,5 @@
+---
+"@pionjs/pion": patch
+---
+
+Run effects on element reattach

--- a/src/create-effect.ts
+++ b/src/create-effect.ts
@@ -40,9 +40,16 @@ function createEffect(setEffects: (state: State, cb: Callable) => void) {
         this._teardown = this.callback.call(this.state);
       }
 
-      teardown(): void {
+      teardown(disconnected?: boolean): void {
         if (typeof this._teardown === "function") {
           this._teardown();
+          // ensure effect is not torn down multiple times
+          this._teardown = undefined;
+        }
+
+        // reset to pristine state when element is disconnected
+        if (disconnected) {
+          this.lastValues = this.values = undefined;
         }
       }
 

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -12,7 +12,7 @@ abstract class Hook<P extends unknown[] = unknown[], R = unknown, H = unknown> {
   }
 
   abstract update(...args: P): R;
-  teardown?(): void;
+  teardown?(disconnected?: boolean): void;
 }
 
 interface CustomHook<

--- a/src/state.ts
+++ b/src/state.ts
@@ -55,7 +55,7 @@ class State<H = unknown> {
     let hooks = this[hookSymbol];
     hooks.forEach((hook) => {
       if (typeof hook.teardown === "function") {
-        hook.teardown();
+        hook.teardown(true);
       }
     });
   }

--- a/test/use-effects.test.ts
+++ b/test/use-effects.test.ts
@@ -86,6 +86,38 @@ describe("useEffect", () => {
     expect(subs.length).to.equal(0);
   });
 
+  it("Runs on reattach", async () => {
+    const tag = "teardown-effect-reattach-test";
+    let setups = 0,
+      teardowns = 0;
+
+    function app() {
+      useEffect(() => {
+        setups++;
+        return () => {
+          teardowns++;
+        };
+      }, []);
+
+      return html`Test`;
+    }
+
+    customElements.define(tag, component(app));
+
+    const el = await fixture(
+      html`<teardown-effect-reattach-test></teardown-effect-reattach-test>`
+    );
+
+    const parent = el.parentNode;
+    el.remove();
+    parent?.append(el);
+
+    await nextFrame();
+
+    expect(setups).to.equal(2, 'the effect was set up twice');
+    expect(teardowns).to.equal(1, 'the effect was cleaned up once');
+  });
+
   it("useEffect(fn, []) runs the effect only once", async () => {
     const tag = "empty-array-effect-test";
     let calls = 0;


### PR DESCRIPTION
Fixed by resetting the internal state of effects when the element is disconnected. This ensures that when it is reconnected, it will run all effects. 

Also fixed an issue where the teardown function is ran twice when re-attaching (once when you detach and once when you attach).

Re matthewp/haunted#492
Re pionjs/pion#58