### PR TITLE
fix: re-create adoptedStyleSheets in cross-document contexts

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -128,20 +128,18 @@ function makeComponent(render: RenderFunction): Creator {
         this._scheduler.update();
         this._scheduler.renderResult?.setConnected(true);
         const allStyleSheets = renderer.styleSheets || _styleSheets;
-        if (allStyleSheets && this.shadowRoot) {
-          const ownerWin = this.ownerDocument?.defaultView;
-          if (ownerWin && ownerWin.CSSStyleSheet !== CSSStyleSheet) {
-            this.shadowRoot.adoptedStyleSheets = allStyleSheets.map((s) => {
-              const cs = new ownerWin.CSSStyleSheet();
-              cs.replaceSync(
-                typeof s === "string"
-                  ? s
-                  : [...s.cssRules].map((r) => r.cssText).join("\n")
-              );
-              return cs;
-            });
-          }
-        }
+        if (!allStyleSheets || !this.shadowRoot) return;
+        const ownerWin = this.ownerDocument?.defaultView;
+        if (!ownerWin || ownerWin.CSSStyleSheet === CSSStyleSheet) return;
+        this.shadowRoot.adoptedStyleSheets = allStyleSheets.map((s) => {
+          const cs = new ownerWin.CSSStyleSheet();
+          cs.replaceSync(
+            typeof s === "string"
+              ? s
+              : [...s.cssRules].map((r) => r.cssText).join("\n")
+          );
+          return cs;
+        });
       }
 
       disconnectedCallback(): void {

--- a/src/component.ts
+++ b/src/component.ts
@@ -127,6 +127,10 @@ function makeComponent(render: RenderFunction): Creator {
         this._scheduler.resume();
         this._scheduler.update();
         this._scheduler.renderResult?.setConnected(true);
+        this.adoptStyleSheets();
+      }
+
+      adoptStyleSheets(): void {
         const allStyleSheets = renderer.styleSheets || _styleSheets;
         if (!allStyleSheets || !this.shadowRoot) return;
         const ownerWin = this.ownerDocument?.defaultView;

--- a/src/component.ts
+++ b/src/component.ts
@@ -127,6 +127,21 @@ function makeComponent(render: RenderFunction): Creator {
         this._scheduler.resume();
         this._scheduler.update();
         this._scheduler.renderResult?.setConnected(true);
+        const allStyleSheets = renderer.styleSheets || _styleSheets;
+        if (allStyleSheets && this.shadowRoot) {
+          const ownerWin = this.ownerDocument?.defaultView;
+          if (ownerWin && ownerWin.CSSStyleSheet !== CSSStyleSheet) {
+            this.shadowRoot.adoptedStyleSheets = allStyleSheets.map((s) => {
+              const cs = new ownerWin.CSSStyleSheet();
+              cs.replaceSync(
+                typeof s === "string"
+                  ? s
+                  : [...s.cssRules].map((r) => r.cssText).join("\n")
+              );
+              return cs;
+            });
+          }
+        }
       }
 
       disconnectedCallback(): void {

--- a/src/component.ts
+++ b/src/component.ts
@@ -130,6 +130,17 @@ function makeComponent(render: RenderFunction): Creator {
         this.adoptStyleSheets();
       }
 
+      /**
+       * Re-creates adoptedStyleSheets for cross-document contexts.
+       *
+       * When a component is rendered into a different document (e.g., a popup
+       * window), the CSSStyleSheet objects created at class-definition time
+       * belong to the parent document and are silently rejected by
+       * shadowRoot.adoptedStyleSheets. This method detects the mismatch
+       * (by comparing the ownerDocument's CSSStyleSheet constructor with the
+       * global one) and re-creates the sheets using the correct window's
+       * constructor so they are accepted by the shadow root.
+       */
       adoptStyleSheets(): void {
         const allStyleSheets = renderer.styleSheets || _styleSheets;
         if (!allStyleSheets || !this.shadowRoot) return;

--- a/test/adopt-stylesheets.test.ts
+++ b/test/adopt-stylesheets.test.ts
@@ -10,152 +10,162 @@ const createIframe = async () => {
 };
 
 describe("adoptStyleSheets", () => {
-	it("applies string styleSheets in same document", async () => {
-		const tag = "same-doc-string-sheets";
-		const style = "div { color: rgb(255, 0, 0); }";
+	describe("same document", () => {
+		it("applies string styleSheets", async () => {
+			const tag = "same-doc-string-sheets";
+			const style = "div { color: rgb(255, 0, 0); }";
 
-		customElements.define(
-			tag,
-			component(() => html`<div class="styled">test</div>`, {
-				styleSheets: [style],
-			})
-		);
+			customElements.define(
+				tag,
+				component(() => html`<div class="styled">test</div>`, {
+					styleSheets: [style],
+				})
+			);
 
-		const el = await fixture(
-			html`<same-doc-string-sheets></same-doc-string-sheets>`
-		);
+			const el = await fixture(
+				html`<same-doc-string-sheets></same-doc-string-sheets>`
+			);
 
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(getComputedStyle(styled).color).to.equal("rgb(255, 0, 0)");
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(getComputedStyle(styled).color).to.equal("rgb(255, 0, 0)");
+		});
+
+		it("applies CSSStyleSheet objects", async () => {
+			const tag = "same-doc-css-stylesheet";
+			const cs = new CSSStyleSheet();
+			cs.replaceSync("div { color: rgb(0, 128, 0); }");
+
+			customElements.define(
+				tag,
+				component(() => html`<div class="styled">test</div>`, {
+					styleSheets: [cs],
+				})
+			);
+
+			const el = await fixture(
+				html`<same-doc-css-stylesheet></same-doc-css-stylesheet>`
+			);
+
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(getComputedStyle(styled).color).to.equal("rgb(0, 128, 0)");
+		});
 	});
 
-	it("applies CSSStyleSheet objects in same document", async () => {
-		const tag = "same-doc-css-stylesheet";
-		const cs = new CSSStyleSheet();
-		cs.replaceSync("div { color: rgb(0, 128, 0); }");
+	describe("cross-document context", () => {
+		let iframe: HTMLIFrameElement;
+		let iframeDoc: Document;
+		let iframeWin: Window;
 
-		customElements.define(
-			tag,
-			component(() => html`<div class="styled">test</div>`, {
-				styleSheets: [cs],
-			})
-		);
+		before(async () => {
+			iframe = await createIframe();
+			iframeDoc = iframe.contentDocument!;
+			iframeWin = iframe.contentWindow!;
+		});
 
-		const el = await fixture(
-			html`<same-doc-css-stylesheet></same-doc-css-stylesheet>`
-		);
+		after(() => {
+			document.body.removeChild(iframe);
+		});
 
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(getComputedStyle(styled).color).to.equal("rgb(0, 128, 0)");
-	});
+		it("applies string styleSheets", async () => {
+			const tag = "cross-doc-string-sheets";
+			const style = "div { color: rgb(255, 0, 0); }";
 
-	it("applies string styleSheets in cross-document context", async () => {
-		const iframe = await createIframe();
-		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+			customElements.define(
+				tag,
+				component(() => html`<div class="styled">test</div>`, {
+					styleSheets: [style],
+				})
+			);
 
-		const tag = "cross-doc-string-sheets";
-		const style = "div { color: rgb(255, 0, 0); }";
+			const el = document.createElement(tag);
+			iframeDoc.body.appendChild(el);
+			await aTimeout(100);
 
-		customElements.define(
-			tag,
-			component(() => html`<div class="styled">test</div>`, {
-				styleSheets: [style],
-			})
-		);
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(iframeWin.getComputedStyle(styled).color).to.equal(
+				"rgb(255, 0, 0)"
+			);
+		});
 
-		const el = document.createElement(tag);
-		iframeDoc!.body.appendChild(el);
-		await aTimeout(100);
+		it("applies CSSStyleSheet objects", async () => {
+			const tag = "cross-doc-css-stylesheet";
+			const cs = new CSSStyleSheet();
+			cs.replaceSync("div { color: rgb(0, 128, 0); }");
 
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
-			"rgb(255, 0, 0)"
-		);
+			customElements.define(
+				tag,
+				component(() => html`<div class="styled">test</div>`, {
+					styleSheets: [cs],
+				})
+			);
 
-		document.body.removeChild(iframe);
-	});
+			const el = document.createElement(tag);
+			iframeDoc.body.appendChild(el);
+			await aTimeout(100);
 
-	it("applies CSSStyleSheet objects in cross-document context", async () => {
-		const iframe = await createIframe();
-		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(iframeWin.getComputedStyle(styled).color).to.equal(
+				"rgb(0, 128, 0)"
+			);
+		});
 
-		const tag = "cross-doc-css-stylesheet";
-		const cs = new CSSStyleSheet();
-		cs.replaceSync("div { color: rgb(0, 128, 0); }");
+		it("applies renderer.styleSheets", async () => {
+			const tag = "cross-doc-renderer-sheets";
+			const style = "div { color: rgb(0, 0, 255); }";
 
-		customElements.define(
-			tag,
-			component(() => html`<div class="styled">test</div>`, {
-				styleSheets: [cs],
-			})
-		);
+			function Renderer(this: any) {
+				return html`<div class="styled">test</div>`;
+			}
+			Renderer.styleSheets = [style];
 
-		const el = document.createElement(tag);
-		iframeDoc!.body.appendChild(el);
-		await aTimeout(100);
+			customElements.define(tag, component(Renderer as any));
 
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
-			"rgb(0, 128, 0)"
-		);
+			const el = document.createElement(tag);
+			iframeDoc.body.appendChild(el);
+			await aTimeout(100);
 
-		document.body.removeChild(iframe);
-	});
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(iframeWin.getComputedStyle(styled).color).to.equal(
+				"rgb(0, 0, 255)"
+			);
+		});
 
-	it("applies renderer.styleSheets in cross-document context", async () => {
-		const iframe = await createIframe();
-		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+		it("applies multiple mixed styleSheets", async () => {
+			const tag = "cross-doc-mixed-sheets";
+			const cs = new CSSStyleSheet();
+			cs.replaceSync("div { color: rgb(255, 0, 0); }");
+			const stringStyle = "div { background-color: rgb(0, 128, 0); }";
 
-		const tag = "cross-doc-renderer-sheets";
-		const style = "div { color: rgb(0, 0, 255); }";
+			customElements.define(
+				tag,
+				component(() => html`<div class="styled">test</div>`, {
+					styleSheets: [cs, stringStyle],
+				})
+			);
 
-		function Renderer(this: any) {
-			return html`<div class="styled">test</div>`;
-		}
-		Renderer.styleSheets = [style];
+			const el = document.createElement(tag);
+			iframeDoc.body.appendChild(el);
+			await aTimeout(100);
 
-		customElements.define(tag, component(Renderer as any));
-
-		const el = document.createElement(tag);
-		iframeDoc!.body.appendChild(el);
-		await aTimeout(100);
-
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
-			"rgb(0, 0, 255)"
-		);
-
-		document.body.removeChild(iframe);
-	});
-
-	it("applies multiple mixed styleSheets in cross-document context", async () => {
-		const iframe = await createIframe();
-		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
-
-		const tag = "cross-doc-mixed-sheets";
-		const cs = new CSSStyleSheet();
-		cs.replaceSync("div { color: rgb(255, 0, 0); }");
-		const stringStyle = "div { background-color: rgb(0, 128, 0); }";
-
-		customElements.define(
-			tag,
-			component(() => html`<div class="styled">test</div>`, {
-				styleSheets: [cs, stringStyle],
-			})
-		);
-
-		const el = document.createElement(tag);
-		iframeDoc!.body.appendChild(el);
-		await aTimeout(100);
-
-		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
-		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
-			"rgb(255, 0, 0)"
-		);
-		expect(iframeWin!.getComputedStyle(styled).backgroundColor).to.equal(
-			"rgb(0, 128, 0)"
-		);
-
-		document.body.removeChild(iframe);
+			const styled = el.shadowRoot!.querySelector(
+				".styled"
+			) as HTMLDivElement;
+			expect(iframeWin.getComputedStyle(styled).color).to.equal(
+				"rgb(255, 0, 0)"
+			);
+			expect(iframeWin.getComputedStyle(styled).backgroundColor).to.equal(
+				"rgb(0, 128, 0)"
+			);
+		});
 	});
 });

--- a/test/adopt-stylesheets.test.ts
+++ b/test/adopt-stylesheets.test.ts
@@ -76,7 +76,7 @@ describe("adoptStyleSheets", () => {
 
 		const sheets = el.shadowRoot!.adoptedStyleSheets;
 		expect(sheets.length).to.equal(1);
-		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
 
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
@@ -107,7 +107,7 @@ describe("adoptStyleSheets", () => {
 
 		const sheets = el.shadowRoot!.adoptedStyleSheets;
 		expect(sheets.length).to.equal(1);
-		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
 		expect(sheets[0]).to.not.equal(cs);
 
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
@@ -138,7 +138,7 @@ describe("adoptStyleSheets", () => {
 
 		const sheets = el.shadowRoot!.adoptedStyleSheets;
 		expect(sheets.length).to.equal(1);
-		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
 
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
@@ -170,8 +170,8 @@ describe("adoptStyleSheets", () => {
 
 		const sheets = el.shadowRoot!.adoptedStyleSheets;
 		expect(sheets.length).to.equal(2);
-		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
-		expect(sheets[1]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
+		expect(sheets[1].constructor).to.equal(iframeWin!.CSSStyleSheet);
 
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(

--- a/test/adopt-stylesheets.test.ts
+++ b/test/adopt-stylesheets.test.ts
@@ -1,0 +1,186 @@
+import { component, html } from "../src/haunted.js";
+import { fixture, expect, aTimeout } from "@open-wc/testing";
+
+const createIframe = async () => {
+	const iframe = document.createElement("iframe");
+	iframe.src = "about:blank";
+	document.body.appendChild(iframe);
+	await aTimeout(100);
+	return iframe;
+};
+
+describe("adoptStyleSheets", () => {
+	it("applies string styleSheets in same document", async () => {
+		const tag = "same-doc-string-sheets";
+		const style = "div { color: rgb(255, 0, 0); }";
+
+		customElements.define(
+			tag,
+			component(() => html`<div class="styled">test</div>`, {
+				styleSheets: [style],
+			})
+		);
+
+		const el = await fixture(
+			html`<same-doc-string-sheets></same-doc-string-sheets>`
+		);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(1);
+		expect(sheets[0]).to.be.instanceOf(CSSStyleSheet);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(getComputedStyle(styled).color).to.equal("rgb(255, 0, 0)");
+	});
+
+	it("applies CSSStyleSheet objects in same document", async () => {
+		const tag = "same-doc-css-stylesheet";
+		const cs = new CSSStyleSheet();
+		cs.replaceSync("div { color: rgb(0, 128, 0); }");
+
+		customElements.define(
+			tag,
+			component(() => html`<div class="styled">test</div>`, {
+				styleSheets: [cs],
+			})
+		);
+
+		const el = await fixture(
+			html`<same-doc-css-stylesheet></same-doc-css-stylesheet>`
+		);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(1);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(getComputedStyle(styled).color).to.equal("rgb(0, 128, 0)");
+	});
+
+	it("re-creates string styleSheets in cross-document context", async () => {
+		const iframe = await createIframe();
+		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+
+		const tag = "cross-doc-string-sheets";
+		const style = "div { color: rgb(255, 0, 0); }";
+
+		customElements.define(
+			tag,
+			component(() => html`<div class="styled">test</div>`, {
+				styleSheets: [style],
+			})
+		);
+
+		const el = document.createElement(tag);
+		iframeDoc!.body.appendChild(el);
+		await aTimeout(100);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(1);
+		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
+			"rgb(255, 0, 0)"
+		);
+
+		document.body.removeChild(iframe);
+	});
+
+	it("re-creates CSSStyleSheet objects in cross-document context", async () => {
+		const iframe = await createIframe();
+		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+
+		const tag = "cross-doc-css-stylesheet";
+		const cs = new CSSStyleSheet();
+		cs.replaceSync("div { color: rgb(0, 128, 0); }");
+
+		customElements.define(
+			tag,
+			component(() => html`<div class="styled">test</div>`, {
+				styleSheets: [cs],
+			})
+		);
+
+		const el = document.createElement(tag);
+		iframeDoc!.body.appendChild(el);
+		await aTimeout(100);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(1);
+		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[0]).to.not.equal(cs);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
+			"rgb(0, 128, 0)"
+		);
+
+		document.body.removeChild(iframe);
+	});
+
+	it("re-creates renderer.styleSheets in cross-document context", async () => {
+		const iframe = await createIframe();
+		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+
+		const tag = "cross-doc-renderer-sheets";
+		const style = "div { color: rgb(0, 0, 255); }";
+
+		function Renderer(this: any) {
+			return html`<div class="styled">test</div>`;
+		}
+		Renderer.styleSheets = [style];
+
+		customElements.define(tag, component(Renderer as any));
+
+		const el = document.createElement(tag);
+		iframeDoc!.body.appendChild(el);
+		await aTimeout(100);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(1);
+		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
+			"rgb(0, 0, 255)"
+		);
+
+		document.body.removeChild(iframe);
+	});
+
+	it("re-creates multiple mixed styleSheets in cross-document context", async () => {
+		const iframe = await createIframe();
+		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
+
+		const tag = "cross-doc-mixed-sheets";
+		const cs = new CSSStyleSheet();
+		cs.replaceSync("div { color: rgb(255, 0, 0); }");
+		const stringStyle = "div { background-color: rgb(0, 128, 0); }";
+
+		customElements.define(
+			tag,
+			component(() => html`<div class="styled">test</div>`, {
+				styleSheets: [cs, stringStyle],
+			})
+		);
+
+		const el = document.createElement(tag);
+		iframeDoc!.body.appendChild(el);
+		await aTimeout(100);
+
+		const sheets = el.shadowRoot!.adoptedStyleSheets;
+		expect(sheets.length).to.equal(2);
+		expect(sheets[0]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+		expect(sheets[1]).to.be.instanceOf(iframeWin!.CSSStyleSheet);
+
+		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
+		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
+			"rgb(255, 0, 0)"
+		);
+		expect(iframeWin!.getComputedStyle(styled).backgroundColor).to.equal(
+			"rgb(0, 128, 0)"
+		);
+
+		document.body.removeChild(iframe);
+	});
+});

--- a/test/adopt-stylesheets.test.ts
+++ b/test/adopt-stylesheets.test.ts
@@ -25,10 +25,6 @@ describe("adoptStyleSheets", () => {
 			html`<same-doc-string-sheets></same-doc-string-sheets>`
 		);
 
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(1);
-		expect(sheets[0]).to.be.instanceOf(CSSStyleSheet);
-
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(getComputedStyle(styled).color).to.equal("rgb(255, 0, 0)");
 	});
@@ -49,14 +45,11 @@ describe("adoptStyleSheets", () => {
 			html`<same-doc-css-stylesheet></same-doc-css-stylesheet>`
 		);
 
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(1);
-
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(getComputedStyle(styled).color).to.equal("rgb(0, 128, 0)");
 	});
 
-	it("re-creates string styleSheets in cross-document context", async () => {
+	it("applies string styleSheets in cross-document context", async () => {
 		const iframe = await createIframe();
 		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
 
@@ -74,10 +67,6 @@ describe("adoptStyleSheets", () => {
 		iframeDoc!.body.appendChild(el);
 		await aTimeout(100);
 
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(1);
-		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
-
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
 			"rgb(255, 0, 0)"
@@ -86,7 +75,7 @@ describe("adoptStyleSheets", () => {
 		document.body.removeChild(iframe);
 	});
 
-	it("re-creates CSSStyleSheet objects in cross-document context", async () => {
+	it("applies CSSStyleSheet objects in cross-document context", async () => {
 		const iframe = await createIframe();
 		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
 
@@ -105,11 +94,6 @@ describe("adoptStyleSheets", () => {
 		iframeDoc!.body.appendChild(el);
 		await aTimeout(100);
 
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(1);
-		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
-		expect(sheets[0]).to.not.equal(cs);
-
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
 			"rgb(0, 128, 0)"
@@ -118,7 +102,7 @@ describe("adoptStyleSheets", () => {
 		document.body.removeChild(iframe);
 	});
 
-	it("re-creates renderer.styleSheets in cross-document context", async () => {
+	it("applies renderer.styleSheets in cross-document context", async () => {
 		const iframe = await createIframe();
 		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
 
@@ -136,10 +120,6 @@ describe("adoptStyleSheets", () => {
 		iframeDoc!.body.appendChild(el);
 		await aTimeout(100);
 
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(1);
-		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
-
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(
 			"rgb(0, 0, 255)"
@@ -148,7 +128,7 @@ describe("adoptStyleSheets", () => {
 		document.body.removeChild(iframe);
 	});
 
-	it("re-creates multiple mixed styleSheets in cross-document context", async () => {
+	it("applies multiple mixed styleSheets in cross-document context", async () => {
 		const iframe = await createIframe();
 		const { contentDocument: iframeDoc, contentWindow: iframeWin } = iframe;
 
@@ -167,11 +147,6 @@ describe("adoptStyleSheets", () => {
 		const el = document.createElement(tag);
 		iframeDoc!.body.appendChild(el);
 		await aTimeout(100);
-
-		const sheets = el.shadowRoot!.adoptedStyleSheets;
-		expect(sheets.length).to.equal(2);
-		expect(sheets[0].constructor).to.equal(iframeWin!.CSSStyleSheet);
-		expect(sheets[1].constructor).to.equal(iframeWin!.CSSStyleSheet);
 
 		const styled = el.shadowRoot!.querySelector(".styled") as HTMLDivElement;
 		expect(iframeWin!.getComputedStyle(styled).color).to.equal(


### PR DESCRIPTION
## Problem

When a pionjs component is rendered into a different document (e.g., a popup window opened via `window.open()`), its `adoptedStyleSheets` silently fail because the `CSSStyleSheet` objects were created in the parent document.

Per the [CSSOM spec](https://drafts.csswg.org/cssom/#dom-cssstylesheet-cssstylesheet), a `CSSStyleSheet` has an internal `[[ConstructorDocument]]` slot set to the document of the realm where `new CSSStyleSheet()` was called. When assigned to `shadowRoot.adoptedStyleSheets` in a different document, the sheets are rejected silently.

This happens because `sheets()` is called at **class-definition time**, creating `CSSStyleSheet` objects in the parent document's realm. These same objects are then shared across all element instances, regardless of which document they're actually rendered in.

## Fix

Detect cross-document elements in `connectedCallback` (where `ownerDocument` reliably reflects the target document, even when lit-html creates elements in the parent document first and then moves them) and re-create the sheets using the correct window's `CSSStyleSheet` constructor.

The check `ownerWin.CSSStyleSheet !== CSSStyleSheet` is a cheap reference comparison. Sheet recreation only happens on mismatch (cross-document), so there's no overhead for the common same-document case.

## Testing

Tested with `cosmoz-image-viewer` which opens a detached popup window and renders `cosmoz-autocomplete` (which uses `component()` with `styleSheets`) inside it. Without this fix, the autocomplete renders unstyled. With this fix, styles are correctly applied.