### PR TITLE
feat: detect and stop infinite update loops

### DIFF
--- a/.changeset/infinite-loop-detection.md
+++ b/.changeset/infinite-loop-detection.md
@@ -1,0 +1,5 @@
+---
+"@pionjs/pion": minor
+---
+
+Detect and stop infinite update loops.

--- a/src/core.ts
+++ b/src/core.ts
@@ -62,6 +62,8 @@ export type { Options as ComponentOptions } from "./component";
 
 export type { StateUpdater } from "./use-state";
 
+export { InfiniteLoopError } from "./errors";
+
 /**
  * Represents any value that can be rendered by lit-html.
  *

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,15 @@
+class InfiniteLoopError extends Error {
+  constructor(component?: string) {
+    const tag = component ? ` <${component}>` : "";
+    super(
+      `Infinite update loop detected in component${tag}. ` +
+        "This usually means a hook (useEffect, useMemo, useCallback) " +
+        "has dependencies that create new references on every render, " +
+        "such as [{}], [[]], or [Promise.resolve()]. " +
+        "Make sure your dependency arrays contain stable references."
+    );
+    this.name = "InfiniteLoopError";
+  }
+}
+
+export { InfiniteLoopError };

--- a/src/scheduler.ts
+++ b/src/scheduler.ts
@@ -9,7 +9,10 @@ import {
   EffectsSymbols,
 } from "./symbols";
 import { GenericRenderer, ComponentOrVirtualComponent } from "./core";
+import { InfiniteLoopError } from "./errors";
 import { ChildPart } from "lit-html";
+
+const MAX_UPDATES = 100;
 
 const defer = Promise.resolve().then.bind(Promise.resolve());
 
@@ -49,6 +52,9 @@ abstract class BaseScheduler<
   [phaseSymbol]: Phase | null;
   _updateQueued: boolean;
   _active: boolean;
+  _updateCount: number;
+  _processing: boolean;
+  static maxUpdates: number = MAX_UPDATES;
 
   constructor(renderer: R, host: H) {
     this.renderer = renderer;
@@ -57,11 +63,32 @@ abstract class BaseScheduler<
     this[phaseSymbol] = null;
     this._updateQueued = false;
     this._active = false;
+    this._updateCount = 0;
+    this._processing = false;
+  }
+
+  private _checkForInfiniteLoop(): void {
+    if (!this._processing) {
+      this._updateCount = 0;
+    }
+    this._updateCount++;
+    if (this._updateCount > BaseScheduler.maxUpdates) {
+      const tagName =
+        this.host instanceof HTMLElement
+          ? this.host.tagName.toLowerCase()
+          : undefined;
+      this._active = false;
+      throw new InfiniteLoopError(tagName);
+    }
   }
 
   update(): void {
     if (!this._active) return;
     if (this._updateQueued) return;
+
+    this._checkForInfiniteLoop();
+
+    this._processing = true;
     read(() => {
       let result = this.handlePhase(updateSymbol);
       write(() => {
@@ -69,6 +96,9 @@ abstract class BaseScheduler<
 
         write(() => {
           this.handlePhase(effectsSymbol);
+          if (!this._updateQueued) {
+            this._processing = false;
+          }
         });
       });
       this._updateQueued = false;
@@ -105,6 +135,8 @@ abstract class BaseScheduler<
 
   teardown(): void {
     this.state.teardown();
+    this._updateCount = 0;
+    this._processing = false;
   }
 
   pause(): void {
@@ -113,6 +145,7 @@ abstract class BaseScheduler<
 
   resume(): void {
     this._active = true;
+    this._updateCount = 0;
   }
 }
 

--- a/test/infinite-loop.test.ts
+++ b/test/infinite-loop.test.ts
@@ -1,0 +1,334 @@
+import { InfiniteLoopError } from "../src/errors.js";
+import { BaseScheduler } from "../src/scheduler.js";
+import { component, html, useEffect, useState } from "../src/haunted.js";
+import { fixture, fixtureCleanup, expect, nextFrame } from "@open-wc/testing";
+
+describe("InfiniteLoopError", () => {
+  it("has correct name and is an Error", () => {
+    const err = new InfiniteLoopError();
+    expect(err.name).to.equal("InfiniteLoopError");
+    expect(err).to.be.instanceof(Error);
+  });
+
+  it("includes component tag name when provided", () => {
+    const err = new InfiniteLoopError("my-component");
+    expect(err.message).to.include("<my-component>");
+  });
+
+  it("works without tag name", () => {
+    const err = new InfiniteLoopError();
+    expect(err.message).to.include("Infinite update loop");
+    expect(err.message).to.not.include("<");
+  });
+
+  it("includes helpful message about unstable deps", () => {
+    const err = new InfiniteLoopError();
+    expect(err.message).to.include("dependency");
+    expect(err.message).to.include("[{}]");
+    expect(err.message).to.include("Promise.resolve()");
+  });
+});
+
+describe("BaseScheduler update counting", () => {
+  it("resets update count on resume", () => {
+    class TestScheduler extends BaseScheduler<
+      object,
+      HTMLElement,
+      () => unknown,
+      HTMLElement
+    > {
+      result: unknown;
+      commit(result: unknown): void {
+        this.result = result;
+      }
+    }
+
+    const host = document.createElement("div");
+    const scheduler = new TestScheduler(() => "test", host);
+
+    expect(scheduler._updateCount).to.equal(0);
+
+    scheduler.resume();
+    expect(scheduler._updateCount).to.equal(0);
+
+    scheduler._updateCount = 50;
+    scheduler.pause();
+    scheduler.resume();
+    expect(scheduler._updateCount).to.equal(0);
+  });
+
+  it("resets update count on teardown", () => {
+    class TestScheduler extends BaseScheduler<
+      object,
+      HTMLElement,
+      () => unknown,
+      HTMLElement
+    > {
+      result: unknown;
+      commit(result: unknown): void {
+        this.result = result;
+      }
+    }
+
+    const host = document.createElement("div");
+    const scheduler = new TestScheduler(() => "test", host);
+    scheduler.resume();
+
+    scheduler._updateCount = 50;
+    scheduler.teardown();
+    expect(scheduler._updateCount).to.equal(0);
+    expect(scheduler._processing).to.be.false;
+  });
+
+  it("has default maxUpdates of 100", () => {
+    expect(BaseScheduler.maxUpdates).to.equal(100);
+  });
+
+  it("allows configuring maxUpdates", () => {
+    const original = BaseScheduler.maxUpdates;
+    BaseScheduler.maxUpdates = 50;
+    expect(BaseScheduler.maxUpdates).to.equal(50);
+    BaseScheduler.maxUpdates = original;
+  });
+});
+
+describe("Infinite loop detection - stable components", () => {
+  afterEach(() => {
+    fixtureCleanup();
+  });
+
+  it("does not interrupt stable effect deps", async () => {
+    const tag = "loop-stable-deps-test";
+    let effectRuns = 0;
+
+    function App() {
+      useEffect(() => {
+        effectRuns++;
+      }, [1, "hello"]);
+      return html`stable`;
+    }
+
+    customElements.define(tag, component(App));
+    const el = await fixture(
+      html`<loop-stable-deps-test></loop-stable-deps-test>`
+    );
+
+    expect(el.shadowRoot!.textContent).to.equal("stable");
+    expect(effectRuns).to.equal(1);
+  });
+
+  it("allows stable state updates after initial mount", async () => {
+    const tag = "loop-stable-state-test";
+    let renders = 0;
+
+    function App() {
+      renders++;
+      const [, setCount] = useState(0);
+
+      useEffect(() => {
+        setCount(1);
+      }, []);
+
+      return html`${renders}`;
+    }
+
+    customElements.define(tag, component(App));
+    const el = await fixture(
+      html`<loop-stable-state-test></loop-stable-state-test>`
+    );
+
+    await nextFrame();
+
+    expect(el.shadowRoot!.textContent).to.be.ok;
+  });
+
+  it("allows multiple state updates with stable deps", async () => {
+    const tag = "loop-multi-deps-test";
+    let renders = 0;
+
+    function App() {
+      const [count, setCount] = useState(0);
+
+      useEffect(() => {
+        if (count < 3) {
+          setCount(count + 1);
+        }
+      }, [count]);
+
+      renders++;
+      return html`${count}`;
+    }
+
+    customElements.define(tag, component(App));
+    const el = await fixture(
+      html`<loop-multi-deps-test></loop-multi-deps-test>`
+    );
+
+    await nextFrame();
+    expect(el.shadowRoot!.textContent).to.equal("3");
+    expect(renders).to.be.lessThan(10);
+  });
+});
+
+describe("Infinite loop detection - unstable deps", () => {
+  const originalMaxUpdates = BaseScheduler.maxUpdates;
+
+  beforeEach(() => {
+    BaseScheduler.maxUpdates = 5;
+  });
+
+  afterEach(() => {
+    BaseScheduler.maxUpdates = originalMaxUpdates;
+    fixtureCleanup();
+    document
+      .querySelectorAll(
+        "loop-unstable-obj-test, loop-unstable-arr-test, loop-unstable-promise-test, loop-stops-render-test, loop-broken-sibling-test, loop-stable-sibling-test"
+      )
+      .forEach((el) => el.remove());
+  });
+
+  function catchUnhandledRejection(timeout = 2000): Promise<InfiniteLoopError> {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        window.removeEventListener("unhandledrejection", handler);
+        reject(new Error(`No InfiniteLoopError caught within ${timeout}ms`));
+      }, timeout);
+      const handler = (e: PromiseRejectionEvent) => {
+        if (e.reason instanceof InfiniteLoopError) {
+          e.preventDefault();
+          clearTimeout(timer);
+          window.removeEventListener("unhandledrejection", handler);
+          resolve(e.reason);
+        }
+      };
+      window.addEventListener("unhandledrejection", handler);
+    });
+  }
+
+  it("stops infinite loop from useEffect with unstable object dep [{}]", async () => {
+    const tag = "loop-unstable-obj-test";
+    const errorPromise = catchUnhandledRejection();
+
+    function App() {
+      const [, setState] = useState(0);
+      useEffect(() => {
+        setState((c: number) => c + 1);
+      }, [{}]);
+      return html`unstable-obj`;
+    }
+
+    customElements.define(tag, component(App));
+    document.body.appendChild(document.createElement(tag));
+
+    const error = await errorPromise;
+    expect(error).to.be.instanceof(InfiniteLoopError);
+    expect(error.message).to.include("loop-unstable-obj-test");
+  });
+
+  it("stops infinite loop from useEffect with unstable array dep [[]]", async () => {
+    const tag = "loop-unstable-arr-test";
+    const errorPromise = catchUnhandledRejection();
+
+    function App() {
+      const [, setState] = useState(0);
+      useEffect(() => {
+        setState((c: number) => c + 1);
+      }, [[]]);
+      return html`unstable-arr`;
+    }
+
+    customElements.define(tag, component(App));
+    document.body.appendChild(document.createElement(tag));
+
+    const error = await errorPromise;
+    expect(error).to.be.instanceof(InfiniteLoopError);
+  });
+
+  it("stops infinite loop from useEffect with unstable Promise.resolve() dep", async () => {
+    const tag = "loop-unstable-promise-test";
+    const errorPromise = catchUnhandledRejection();
+
+    function App() {
+      const [, setState] = useState(0);
+      useEffect(() => {
+        setState((c: number) => c + 1);
+      }, [Promise.resolve()]);
+      return html`unstable-promise`;
+    }
+
+    customElements.define(tag, component(App));
+    document.body.appendChild(document.createElement(tag));
+
+    const error = await errorPromise;
+    expect(error).to.be.instanceof(InfiniteLoopError);
+  });
+
+  it("component stops rendering after loop is detected", async () => {
+    const tag = "loop-stops-render-test";
+    const errorPromise = catchUnhandledRejection();
+    let renders = 0;
+
+    function App() {
+      renders++;
+      const [, setState] = useState(0);
+      useEffect(() => {
+        setState((c: number) => c + 1);
+      }, [{}]);
+      return html`${renders}`;
+    }
+
+    customElements.define(tag, component(App));
+    const el = document.createElement(tag);
+    document.body.appendChild(el);
+
+    await errorPromise;
+    const rendersAtDetection = renders;
+
+    await nextFrame();
+    await nextFrame();
+
+    // No further renders after detection
+    expect(renders).to.equal(rendersAtDetection);
+  });
+
+  it("does not break sibling components when one enters infinite loop", async () => {
+    const brokenTag = "loop-broken-sibling-test";
+    const stableTag = "loop-stable-sibling-test";
+    const errorPromise = catchUnhandledRejection();
+
+    function BrokenApp() {
+      const [, setState] = useState(0);
+      useEffect(() => {
+        setState((c: number) => c + 1);
+      }, [{}]);
+      return html`broken`;
+    }
+
+    let stableRenders = 0;
+    function StableApp() {
+      const [count, setCount] = useState(0);
+      stableRenders++;
+      useEffect(() => {
+        if (count === 0) setCount(1);
+      }, [count]);
+      return html`${count}`;
+    }
+
+    customElements.define(brokenTag, component(BrokenApp));
+    customElements.define(stableTag, component(StableApp));
+
+    // Append both synchronously — they share microtask batches
+    const broken = document.createElement(brokenTag);
+    const stable = document.createElement(stableTag);
+    document.body.appendChild(broken);
+    document.body.appendChild(stable);
+
+    await errorPromise;
+    await nextFrame();
+    await nextFrame();
+
+    // Stable component should complete its 0→1 state transition
+    expect(stable.shadowRoot!.textContent).to.equal("1");
+    expect(stableRenders).to.be.greaterThan(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Components with unstable effect dependencies (e.g. `[{}]`, `[[]]`, `[Promise.resolve()]`) no longer freeze the browser
- After 100 cascading updates, the scheduler throws `InfiniteLoopError` and deactivates the component
- Sibling components are unaffected

## Implementation

- `InfiniteLoopError` class with diagnostic message pointing to common causes
- `_processing` flag in `BaseScheduler` tracks whether updates are part of an ongoing cascade
- Counter only resets when no cascading update is queued
- `InfiniteLoopError` exported from `@pionjs/pion`

## Tests

- Error class unit tests
- Scheduler counter/reset logic tests
- Stable component integration tests (no false positives)
- Unstable deps integration tests (`[{}]`, `[[]]`, `[Promise.resolve()]`)
- Rendering stops after detection
- Sibling components survive