### PR TITLE
feat: bubble functional state updaters through lift

### DIFF
--- a/.changeset/warm-lions-bubble.md
+++ b/.changeset/warm-lions-bubble.md
@@ -1,0 +1,15 @@
+---
+"@pionjs/pion": minor
+---
+
+Allow `lift` to bubble functional state updaters to parent components
+
+`useProperty` now bubbles the original updater function via `ev.detail.updater` in the change event, alongside `ev.detail.value`. `lift` passes `ev.detail.updater ?? ev.detail.value` to the parent's setter, so functional updaters resolve against the parent's authoritative state instead of the child's potentially stale `host[property]`.
+
+This fixes rapid-fire functional updater calls (e.g., `setItems((items) => [...items, item])`) producing incorrect state when used with `lift`, because the child's local state was blocked by `preventDefault()` and hadn't yet been updated by the parent re-render.
+
+### Breaking changes
+
+- `useProperty.updateProp` removed (was internal, not part of public API)
+- Event detail shape now includes `updater` field alongside `value`
+- `lift` now passes `ev.detail.updater ?? ev.detail.value` to setter (was `ev.detail.value`)

--- a/.changeset/warm-lions-bubble.md
+++ b/.changeset/warm-lions-bubble.md
@@ -4,13 +4,15 @@
 
 Allow `lift` to bubble functional state updaters to parent components
 
-`useProperty` now bubbles the original updater function via `ev.detail.updater` in the change event, alongside `ev.detail.value`. `lift` passes `ev.detail.updater ?? ev.detail.value` to the parent's setter, so functional updaters resolve against the parent's authoritative state instead of the child's potentially stale `host[property]`.
+`useProperty` now resolves the updater function against `host[property]` before dispatching the event, so `ev.detail.value` always contains the resolved value. The original updater function is also included in `ev.detail.updater` for `lift` to pass to the parent setter, which resolves it against the parent's authoritative state.
 
 This fixes rapid-fire functional updater calls (e.g., `setItems((items) => [...items, item])`) producing incorrect state when used with `lift`, because the child's local state was blocked by `preventDefault()` and hadn't yet been updated by the parent re-render.
 
 ### Breaking changes
 
 - `useProperty.updateProp` removed (was internal, not part of public API)
+- `useProperty.init` removed (was internal, not part of public API)
 - Event detail shape now includes `updater` field alongside `value`
+- `ev.detail.value` is always the resolved value (was `undefined` for functional updaters)
 - `lift` now passes `ev.detail.updater ?? ev.detail.value` to setter (was `ev.detail.value`)
-- `useProperty` setter now always dispatches a change event, even if the value is unchanged. Previously, setting the same value would silently skip the event. This allows `lift` to always receive the updater function.
+- `useProperty` setter now always dispatches a change event, even if the value is unchanged

--- a/.changeset/warm-lions-bubble.md
+++ b/.changeset/warm-lions-bubble.md
@@ -13,3 +13,4 @@ This fixes rapid-fire functional updater calls (e.g., `setItems((items) => [...i
 - `useProperty.updateProp` removed (was internal, not part of public API)
 - Event detail shape now includes `updater` field alongside `value`
 - `lift` now passes `ev.detail.updater ?? ev.detail.value` to setter (was `ev.detail.value`)
+- `useProperty` setter now always dispatches a change event, even if the value is unchanged. Previously, setting the same value would silently skip the event. This allows `lift` to always receive the updater function.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pionjs/pion",
-  "version": "2.14.0",
+  "version": "2.15.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pionjs/pion",
-      "version": "2.14.0",
+      "version": "2.15.0",
       "license": "BSD-2-Clause",
       "dependencies": {
         "lit-html": "^2.0.0 || ^3.0.0"

--- a/src/use-property.ts
+++ b/src/use-property.ts
@@ -53,13 +53,7 @@ export const useProperty = hook(
 
       if (initialValue == null) return;
 
-      this.init(initialValue);
-    }
-
-    init(value: T): void {
-      const ev = this.notify(value);
-      if (ev.defaultPrevented) return;
-      this.commit(value);
+      this.updater(initialValue);
     }
 
     update(ignored: string, ignored2: T): StateTuple<T> {

--- a/src/use-property.ts
+++ b/src/use-property.ts
@@ -67,11 +67,6 @@ export const useProperty = hook(
     }
 
     updater(valueOrUpdater: NewState<T>): void {
-      if (
-        typeof valueOrUpdater !== "function" &&
-        Object.is(this.state.host[this.property], valueOrUpdater)
-      )
-        return;
       const ev = this.notify(valueOrUpdater);
       if (ev.defaultPrevented) return;
       this.commit(valueOrUpdater);

--- a/src/use-property.ts
+++ b/src/use-property.ts
@@ -3,13 +3,12 @@ import { State } from "./state";
 import type {
   InitialState,
   NewState,
-  StateUpdater,
   StateTuple,
 } from "./use-state";
 
 type Host<T> = Element & { [key: string]: T };
 type ChangeEvent<T> = {
-  value: T | undefined;
+  value: T;
   updater: ((previousState: T) => T) | undefined;
   path: string;
 };
@@ -60,44 +59,42 @@ export const useProperty = hook(
       return [this.state.host[this.property], this.updater];
     }
 
-    updater(valueOrUpdater: NewState<T>): void {
-      const ev = this.notify(valueOrUpdater);
-      if (ev.defaultPrevented) return;
-      this.commit(valueOrUpdater);
-    }
-
-    commit(valueOrUpdater: NewState<T>): void {
+    resolve(
+      valueOrUpdater: NewState<T>
+    ): [previousValue: T, value: T, updater: ((previousState: T) => T) | undefined] {
       const previousValue = this.state.host[this.property];
-      const value =
-        typeof valueOrUpdater === "function"
-          ? (valueOrUpdater as (previousState: T) => T)(previousValue)
-          : valueOrUpdater;
-      if (Object.is(previousValue, value)) return;
-      this.state.host[this.property] = value;
-    }
-
-    notify(valueOrUpdater: NewState<T>) {
       const updater =
         typeof valueOrUpdater === "function"
           ? (valueOrUpdater as (previousState: T) => T)
           : undefined;
+      const value = updater
+        ? updater(previousValue)
+        : (valueOrUpdater as T);
+      return [previousValue, value, updater];
+    }
+
+    notify(value: T, updater?: (previousState: T) => T) {
       const ev = new CustomEvent<ChangeEvent<T>>(this.eventName, {
-        detail: {
-          value: updater ? undefined : (valueOrUpdater as T),
-          updater,
-          path: this.property,
-        },
+        detail: { value, updater, path: this.property },
         cancelable: true,
       });
       this.state.host.dispatchEvent(ev);
       return ev;
     }
+
+    updater(valueOrUpdater: NewState<T>): void {
+      const [previousValue, value, updater] = this.resolve(valueOrUpdater);
+      const ev = this.notify(value, updater);
+      if (ev.defaultPrevented) return;
+      if (Object.is(previousValue, value)) return;
+      this.state.host[this.property] = value;
+    }
   }
 ) as UseProperty;
 
 export const lift =
-  <T>(setter: StateUpdater<T> | ((value: NewState<T>) => void)) =>
+  <T>(setter: (value: T | ((previousState: T) => T)) => void) =>
   (ev: CustomEvent<ChangeEvent<T>>) => {
     ev.preventDefault();
-    setter(ev.detail.updater ?? (ev.detail.value as NewState<T>));
+    setter(ev.detail.updater ?? ev.detail.value);
   };

--- a/src/use-property.ts
+++ b/src/use-property.ts
@@ -9,7 +9,8 @@ import type {
 
 type Host<T> = Element & { [key: string]: T };
 type ChangeEvent<T> = {
-  value: T;
+  value: T | undefined;
+  updater: ((previousState: T) => T) | undefined;
   path: string;
 };
 
@@ -52,37 +53,51 @@ export const useProperty = hook(
 
       if (initialValue == null) return;
 
-      this.updateProp(initialValue);
+      this.init(initialValue);
+    }
+
+    init(value: T): void {
+      const ev = this.notify(value);
+      if (ev.defaultPrevented) return;
+      this.commit(value);
     }
 
     update(ignored: string, ignored2: T): StateTuple<T> {
       return [this.state.host[this.property], this.updater];
     }
 
-    updater(value: NewState<T>): void {
-      const previousValue = this.state.host[this.property];
-
-      if (typeof value === "function") {
-        const updaterFn = value as (previousState: T) => T;
-        value = updaterFn(previousValue);
-      }
-
-      if (Object.is(previousValue, value)) {
+    updater(valueOrUpdater: NewState<T>): void {
+      if (
+        typeof valueOrUpdater !== "function" &&
+        Object.is(this.state.host[this.property], valueOrUpdater)
+      )
         return;
-      }
-
-      this.updateProp(value);
+      const ev = this.notify(valueOrUpdater);
+      if (ev.defaultPrevented) return;
+      this.commit(valueOrUpdater);
     }
 
-    updateProp(value: T): void {
-      const ev = this.notify(value);
-      if (ev.defaultPrevented) return;
+    commit(valueOrUpdater: NewState<T>): void {
+      const previousValue = this.state.host[this.property];
+      const value =
+        typeof valueOrUpdater === "function"
+          ? (valueOrUpdater as (previousState: T) => T)(previousValue)
+          : valueOrUpdater;
+      if (Object.is(previousValue, value)) return;
       this.state.host[this.property] = value;
     }
 
-    notify(value: T) {
+    notify(valueOrUpdater: NewState<T>) {
+      const updater =
+        typeof valueOrUpdater === "function"
+          ? (valueOrUpdater as (previousState: T) => T)
+          : undefined;
       const ev = new CustomEvent<ChangeEvent<T>>(this.eventName, {
-        detail: { value, path: this.property },
+        detail: {
+          value: updater ? undefined : (valueOrUpdater as T),
+          updater,
+          path: this.property,
+        },
         cancelable: true,
       });
       this.state.host.dispatchEvent(ev);
@@ -92,8 +107,8 @@ export const useProperty = hook(
 ) as UseProperty;
 
 export const lift =
-  <T>(setter: (value: T) => void) =>
+  <T>(setter: StateUpdater<T> | ((value: NewState<T>) => void)) =>
   (ev: CustomEvent<ChangeEvent<T>>) => {
     ev.preventDefault();
-    setter(ev.detail.value);
+    setter(ev.detail.updater ?? (ev.detail.value as NewState<T>));
   };

--- a/test/use-property.test.ts
+++ b/test/use-property.test.ts
@@ -248,4 +248,182 @@ describe("useProperty", () => {
     render(vApp(), el);
     expect(spy).to.not.have.been.calledOnce;
   });
+
+  it("event detail contains updater for functional calls", async () => {
+    const tag = "use-property-event-detail-updater";
+    const spy = Sinon.spy();
+    let setter;
+
+    function App() {
+      let [age, setAge] = useProperty("age", () => 8);
+      setter = setAge;
+      return html`<span>${age}</span>`;
+    }
+
+    customElements.define(tag, component(App));
+
+    await fixture<HTMLElement>(
+      html`<use-property-event-detail-updater
+        @age-changed=${spy}
+      ></use-property-event-detail-updater>`
+    );
+
+    setter((value) => value + 1);
+
+    expect(spy).to.have.been.calledTwice;
+    expect(spy.secondCall).to.have.been.calledWithMatch({
+      detail: { value: undefined, updater: Sinon.match.func },
+    });
+  });
+
+  it("event detail contains value for direct calls", async () => {
+    const tag = "use-property-event-detail-value";
+    const spy = Sinon.spy();
+    let setter;
+
+    function App() {
+      let [age, setAge] = useProperty("age", () => 8);
+      setter = setAge;
+      return html`<span>${age}</span>`;
+    }
+
+    customElements.define(tag, component(App));
+
+    await fixture<HTMLElement>(
+      html`<use-property-event-detail-value
+        @age-changed=${spy}
+      ></use-property-event-detail-value>`
+    );
+
+    setter(20);
+
+    expect(spy).to.have.been.calledTwice;
+    expect(spy.secondCall).to.have.been.calledWithMatch({
+      detail: { value: 20, updater: undefined },
+    });
+  });
+
+  it("lift bubbles functional updater to parent", async () => {
+    let childSetter;
+
+    function Parent() {
+      let [count, setCount] = useState(0);
+      return html`<use-property-lift-updater-child
+        .count=${count}
+        @count-changed=${lift(setCount)}
+      ></use-property-lift-updater-child>`;
+    }
+
+    function Child() {
+      let [count, setCount] = useProperty("count", 0);
+      childSetter = setCount;
+      return html`<span>${count}</span>`;
+    }
+
+    customElements.define(
+      "use-property-lift-updater-parent",
+      component(Parent)
+    );
+    customElements.define(
+      "use-property-lift-updater-child",
+      component(Child)
+    );
+
+    const el = await fixture<HTMLElement>(
+      html`<use-property-lift-updater-parent></use-property-lift-updater-parent>`
+    );
+    const child = el.shadowRoot?.firstElementChild as HTMLElement;
+    const span = child?.shadowRoot?.firstElementChild;
+
+    expect(span?.textContent).to.equal("0");
+
+    childSetter((c) => c + 1);
+    await nextFrame();
+    expect(span?.textContent).to.equal("1");
+
+    childSetter((c) => c + 1);
+    await nextFrame();
+    expect(span?.textContent).to.equal("2");
+  });
+
+  it("rapid-fire functional updaters with lift accumulate correctly", async () => {
+    let childSetter;
+
+    function Parent() {
+      let [items, setItems] = useState<string[]>([]);
+      return html`<use-property-rapid-fire-child
+        .items=${items}
+        @items-changed=${lift(setItems)}
+      ></use-property-rapid-fire-child>`;
+    }
+
+    function Child() {
+      let [items, setItems] = useProperty<string[]>("items", () => []);
+      childSetter = setItems;
+      return html`<span>${items.join(",")}</span>`;
+    }
+
+    customElements.define(
+      "use-property-rapid-fire-parent",
+      component(Parent)
+    );
+    customElements.define(
+      "use-property-rapid-fire-child",
+      component(Child)
+    );
+
+    const el = await fixture<HTMLElement>(
+      html`<use-property-rapid-fire-parent></use-property-rapid-fire-parent>`
+    );
+    const child = el.shadowRoot?.firstElementChild as HTMLElement;
+    const span = child?.shadowRoot?.firstElementChild;
+
+    expect(span?.textContent).to.equal("");
+
+    childSetter((items) => [...items, "a"]);
+    childSetter((items) => [...items, "b"]);
+    childSetter((items) => [...items, "c"]);
+
+    await nextFrame();
+    expect(span?.textContent).to.equal("a,b,c");
+  });
+
+  it("lift with direct value still works", async () => {
+    let childSetter;
+
+    function Parent() {
+      let [age, setAge] = useState(20);
+      return html`<use-property-lift-direct-child
+        .age=${age}
+        @age-changed=${lift(setAge)}
+      ></use-property-lift-direct-child>`;
+    }
+
+    function Child() {
+      let [age, setAge] = useProperty("age", 2);
+      childSetter = setAge;
+      return html`<span>${age}</span>`;
+    }
+
+    customElements.define(
+      "use-property-lift-direct-parent",
+      component(Parent)
+    );
+    customElements.define(
+      "use-property-lift-direct-child",
+      component(Child)
+    );
+
+    const el = await fixture<HTMLElement>(
+      html`<use-property-lift-direct-parent></use-property-lift-direct-parent>`
+    );
+    const child = el.shadowRoot?.firstElementChild as HTMLElement;
+    const span = child?.shadowRoot?.firstElementChild;
+
+    expect(span?.textContent).to.equal("20");
+
+    childSetter(30);
+    await nextFrame();
+    expect(span?.textContent).to.equal("30");
+  });
 });

--- a/test/use-property.test.ts
+++ b/test/use-property.test.ts
@@ -80,18 +80,21 @@ describe("useProperty", () => {
 
     expect(spy).to.have.been.calledOnce;
     expect(spy).to.have.been.calledWithMatch({
-      detail: { value: 8 },
+      detail: { value: 8, updater: undefined },
     });
 
     setter(20);
     expect(spy).to.have.been.calledTwice;
     expect(spy).to.have.been.calledWithMatch({
-      detail: { value: 20 },
+      detail: { value: 20, updater: undefined },
     });
 
-    // does not notify if the same value is already set
+    // always notifies, even if the same value is already set
     setter(20);
-    expect(spy).to.have.been.calledTwice;
+    expect(spy).to.have.been.calledThrice;
+    expect(spy).to.have.been.calledWithMatch({
+      detail: { value: 20, updater: undefined },
+    });
   });
 
   it("does not notify when the initial value is undefined", async () => {

--- a/test/use-property.test.ts
+++ b/test/use-property.test.ts
@@ -275,7 +275,7 @@ describe("useProperty", () => {
 
     expect(spy).to.have.been.calledTwice;
     expect(spy.secondCall).to.have.been.calledWithMatch({
-      detail: { value: undefined, updater: Sinon.match.func },
+      detail: { value: 9, updater: Sinon.match.func },
     });
   });
 


### PR DESCRIPTION
## Problem

When `lift` is used to delegate property ownership to a parent component, rapid-fire calls to `useProperty`'s setter with functional updaters produce incorrect state. Each call reads stale `host[property]` because `lift`'s `preventDefault()` blocks the local write, and the parent hasn't re-rendered yet. See #149 for full analysis.

## Solution

**Notify first, compute after.** If `defaultPrevented` (i.e., `lift` intercepted), skip the local write. If not prevented, commit the resolved value.

Bubble the **original updater function** in `ev.detail.updater` so `lift` can pass it to the parent's setter. The parent's setter is itself a `useProperty` updater that calls `resolve()` against its own `host[property]` — the authoritative state. Meanwhile, `ev.detail.value` always contains the locally-resolved value for backward compatibility with non-lift listeners.

### Method breakdown

| Method | Responsibility |
|--------|---------------|
| **`resolve(valueOrUpdater)`** | Given a value or updater function, compute `[previousValue, value, updater]`. Resolves functions against `host[property]`. |
| **`notify(value, updater?)`** | Dispatch event with `{ value, updater, path }` in detail. `value` is always the resolved value. Returns event. |
| **`updater(valueOrUpdater)`** | Orchestrate: resolve → notify → if prevented return → dedup+write. Called from constructor for init and at runtime. |

`updateProp`, `init`, and `commit` removed — replaced by `resolve` + `notify` + inline dedup/write.

### Event detail

`ev.detail` now always contains:
- **`value`**: the resolved value (computed against `host[property]`). Always present, never `undefined`.
- **`updater`**: the original updater function for functional calls, `undefined` for direct values. Used by `lift` to resolve against parent state.
- **`path`**: unchanged.

### Flow for rapid-fire calls with lift

```
select(item1) → updater((sel) => [...sel, item1])
  → resolve: previousValue=[], value=[item1], updater=fn
  → notify({ value: [item1], updater: fn })
  → lift: ev.preventDefault(), setter(fn)
  → parent updater: resolve against parentHost.selectedItems=[] → value=[item1]
  → parent notify → not prevented → write parentHost.selectedItems=[item1]
  → child: defaultPrevented, return (no local write)

select(item2) → updater((sel) => [...sel, item2])
  → resolve: previousValue=[] (stale), value=[item2], updater=fn
  → notify({ value: [item2], updater: fn })
  → lift: setter(fn)
  → parent updater: resolve against parentHost.selectedItems=[item1] → value=[item1, item2]
  → parent notify → not prevented → write parentHost.selectedItems=[item1, item2]
  → child: defaultPrevented, return
```

Each call resolves correctly at the parent level because `lift` passes the updater function, not the locally-resolved value.

### Backward Compatibility

- **`ev.detail.value`**: always the resolved value. Previously was the resolved value for direct calls only. Non-lift listeners that read `ev.detail.value` get correct values for both direct and functional updaters.
- **`ev.detail.updater`**: new optional field — only used by `lift`.
- **`ev.detail.path`**: unchanged.

### Breaking changes

- `useProperty.updateProp` removed (was internal, not part of public API)
- `useProperty.init` removed (was internal, not part of public API)
- Event detail shape now includes `updater` field alongside `value`
- `ev.detail.value` is always the resolved value (was `undefined` for functional updaters)
- `lift` now passes `ev.detail.updater ?? ev.detail.value` to setter (was `ev.detail.value`)
- `useProperty` setter now always dispatches a change event, even if the value is unchanged

### Tests

94 tests passing (89 existing + 5 new):
- "event detail contains updater for functional calls" — verifies `ev.detail.value` is resolved (9, not undefined) and `ev.detail.updater` is the function
- "event detail contains value for direct calls" — verifies `ev.detail.value` is the value and `ev.detail.updater` is undefined
- "lift bubbles functional updater to parent" — child calls functional setter, parent lift intercepts
- "rapid-fire functional updaters with lift accumulate correctly" — 3 synchronous `setItems((items) => [...items, x])` calls produce `a,b,c`
- "lift with direct value still works" — direct values still work with lift