### PR TITLE
fix: upgrade TypeScript to 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@web/dev-server-esbuild": "^1.0.0",
         "@web/test-runner": "^0.20.0",
         "sinon": "^22.0.0",
-        "typescript": "^5.2.0"
+        "typescript": "^6.0.3"
       }
     },
     "docs": {
@@ -421,6 +421,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@custom-elements-manifest/find-dependencies": {
@@ -8837,9 +8851,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -9691,6 +9705,12 @@
             "merge2": "^1.3.0",
             "slash": "^3.0.0"
           }
+        },
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+          "dev": true
         }
       }
     },
@@ -15906,9 +15926,9 @@
       }
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@web/dev-server-esbuild": "^1.0.0",
     "@web/test-runner": "^0.20.0",
     "sinon": "^22.0.0",
-    "typescript": "^5.2.0"
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "lit-html": "^2.0.0 || ^3.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "outDir": "lib",
     "declaration": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
+    "rootDir": "./src",
     "strict": true,
     "skipLibCheck": true,
     "target": "esnext"


### PR DESCRIPTION
## Changes

- Bump `typescript` from `^5.2.0` to `^6.0.3`
- Set `moduleResolution: "bundler"` (replaces deprecated `node`)
- Add `rootDir: "./src"` (required by TypeScript 6.0)

## Notes

TypeScript 6.0 deprecated `moduleResolution: node` (alias for `node10`) and now requires `rootDir` to be explicitly set. Using `bundler` resolution is the right choice for this project since it uses `tsc` as a transpiler without a bundler.