### PR TITLE
fix: useProperty init sets default even when preventDefault is called

### DIFF
--- a/.changeset/fe-887-use-property-init.md
+++ b/.changeset/fe-887-use-property-init.md
@@ -1,0 +1,14 @@
+---
+"@pionjs/pion": patch
+---
+
+Fix: useProperty initialization sets default value even when preventDefault is called
+
+When a parent component uses `lift()` to listen to a property change event without
+passing the property value to the child, `useProperty`'s initialization event was
+`preventDefault`'d by `lift`, leaving the host property `undefined`. This caused crashes
+in components like `cosmoz-omnitable` where `selectedItems` was never initialized.
+
+The `updater` method now accepts an `isInit` flag that bypasses the `preventDefault` veto
+during initialization, ensuring the host always receives its default value. Subsequent
+updates retain the full `lift`/`preventDefault` two-way binding semantics.

--- a/src/use-property.ts
+++ b/src/use-property.ts
@@ -52,7 +52,7 @@ export const useProperty = hook(
 
       if (initialValue == null) return;
 
-      this.updater(initialValue);
+      this.updater(initialValue, true);
     }
 
     update(ignored: string, ignored2: T): StateTuple<T> {
@@ -82,10 +82,10 @@ export const useProperty = hook(
       return ev;
     }
 
-    updater(valueOrUpdater: NewState<T>): void {
+    updater(valueOrUpdater: NewState<T>, isInit = false): void {
       const [previousValue, value, updater] = this.resolve(valueOrUpdater);
       const ev = this.notify(value, updater);
-      if (ev.defaultPrevented) return;
+      if (!isInit && ev.defaultPrevented) return;
       if (Object.is(previousValue, value)) return;
       this.state.host[this.property] = value;
     }

--- a/test/use-property.test.ts
+++ b/test/use-property.test.ts
@@ -391,6 +391,41 @@ describe("useProperty", () => {
     expect(span?.textContent).to.equal("a,b,c");
   });
 
+  it("initializes default value even when lift prevents default", async () => {
+    let parentSetter;
+
+    function Parent() {
+      let [items, setItems] = useState<string[] | undefined>(undefined);
+      parentSetter = setItems;
+      return html`<use-property-lift-no-prop-child
+        @items-changed=${lift(setItems)}
+      ></use-property-lift-no-prop-child>`;
+    }
+
+    function Child() {
+      let [items, setItems] = useProperty<string[]>("items", () => []);
+      return html`<span>${(items ?? []).length}</span>`;
+    }
+
+    customElements.define(
+      "use-property-lift-no-prop-parent",
+      component(Parent)
+    );
+    customElements.define(
+      "use-property-lift-no-prop-child",
+      component(Child)
+    );
+
+    const el = await fixture<HTMLElement>(
+      html`<use-property-lift-no-prop-parent></use-property-lift-no-prop-parent>`
+    );
+    const child = el.shadowRoot?.firstElementChild as HTMLElement;
+    const span = child?.shadowRoot?.firstElementChild;
+
+    expect(child?.items).to.deep.equal([]);
+    expect(span?.textContent).to.equal("0");
+  });
+
   it("lift with direct value still works", async () => {
     let childSetter;
 

--- a/test/use-property.test.ts
+++ b/test/use-property.test.ts
@@ -404,7 +404,7 @@ describe("useProperty", () => {
 
     function Child() {
       let [items, setItems] = useProperty<string[]>("items", () => []);
-      return html`<span>${(items ?? []).length}</span>`;
+      return html`<span>${items.length}</span>`;
     }
 
     customElements.define(


### PR DESCRIPTION
## Problem

When a parent component uses `lift()` to listen to a child's property change event without passing the property value to the child (no `.prop=${value}` binding), `useProperty`'s initialization is blocked by `preventDefault()`, leaving the host property `undefined`.

This causes `TypeError: Cannot read properties of undefined (reading 'length')` crashes in components like `cosmoz-omnitable`'s `renderFooter` when `selectedItems` is never initialized.

### Root cause

`useProperty`'s constructor calls `this.updater(initialValue)` to set the default. `updater` dispatches a notification event, and if a `lift` listener calls `ev.preventDefault()`, the host property is never set:

```js
updater(valueOrUpdater) {
    const ev = this.notify(value, updater);
    if (ev.defaultPrevented) return;  // ← host property never set on init!
    // ...
    this.state.host[this.property] = value;
}
```

This is correct for **subsequent updates** (parent takes over via its own state), but wrong for **initialization** — the host should always get its default value.

## Fix

Add an `isInit` flag to `updater()` that bypasses the `preventDefault` veto during initialization:

```js
updater(valueOrUpdater, isInit = false) {
    const ev = this.notify(value, updater);
    if (!isInit && ev.defaultPrevented) return;  // only veto non-init updates
    // ...
}
```

Constructor passes `true`:
```js
this.updater(initialValue, true);
```

This ensures:
- The host always gets its default value on init
- The notification event still fires (so `lift` syncs parent state)
- Subsequent updates retain full `preventDefault` / `lift` two-way binding semantics

## Test

Added a test reproducing the exact scenario: parent uses `lift` without passing the property, verifying the child's host gets the default `[]`.