### PR TITLE
docs: add Umami analytics tracking

### DIFF
--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -1,0 +1,5 @@
+---
+import Default from '@astrojs/starlight/components/Head.astro';
+---
+<Default />
+<script defer src="https://cloud.umami.is/script.js" data-website-id="8bd77f5a-a2da-4856-8963-3b95c7ce1302"></script>


### PR DESCRIPTION
Adds Umami analytics to the documentation site.

- Creates  to override Starlight's default Head component
- Injects the Umami tracking script into `<head>` on every page

No config changes needed — Starlight auto-resolves component overrides from `src/components/`.