### PR TITLE
docs: SEO fixes — sitemap domain, redirects, index pages, meta tags, structured data

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 
 export default defineConfig({
-  site: 'https://pionjs.github.io/pion',
+  site: 'https://pionjs.com',
   integrations: [
     starlight({
       title: 'pion',
@@ -24,6 +24,7 @@ export default defineConfig({
       sidebar: [
         {
           label: 'Guides',
+          collapsed: true,
           items: [
             { label: 'Getting Started', slug: 'guides/getting-started' },
             { label: 'Bring Your Own Renderer', slug: 'guides/renderers' },
@@ -37,6 +38,7 @@ export default defineConfig({
         },
         {
           label: 'Hooks',
+          collapsed: true,
           items: [
             { label: 'useCallback', slug: 'hooks/usecallback' },
             { label: 'useContext', slug: 'hooks/usecontext' },

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
       tagline: 'Hooks for Web Components',
       logo: {
         src: './src/assets/logo.svg',
+        alt: 'pion',
       },
       social: [
         {

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,4 @@
+/docs/                    /                           301
+/docs/guides/             /guides/                    301
+/docs/guides/:path        /guides/:path               301
+/docs/hooks/:path         /hooks/:path                301

--- a/docs/public/llms.txt
+++ b/docs/public/llms.txt
@@ -1,0 +1,46 @@
+# pion
+
+> pion brings React's Hooks API to standard Web Components. Write
+> functions with useState, useEffect, useReducer, and more that become
+> Custom Elements via `component()`. Works with lit-html or any template
+> renderer. An alternative to React/Vue/Svelte for standards-based
+> components, and to Lit/Stencil for developers wanting React-style
+> state management without a framework. Forked from haunted.
+
+pion supports the same hooks API as React, so existing hooks from npm
+can be reused by aliasing package names in your bundler config. Components
+are plain functions that return a lit-html template; calling `component()`
+wraps the function into a custom element you register with
+`customElements.define`.
+
+## Getting Started
+
+- [Getting Started](https://pionjs.com/guides/getting-started/): Install pion and build your first hook-powered Web Component
+- [Bring Your Own Renderer](https://pionjs.com/guides/renderers/): Use lighterhtml, hyperHTML, or any template library via the core build
+- [API](https://pionjs.com/guides/api/): Reference for `component()` and `virtual()`
+
+## Guides
+
+- [Attributes](https://pionjs.com/guides/attributes/): Define observedAttributes and pass string values from HTML
+- [Properties](https://pionjs.com/guides/properties/): Bind non-string values to custom element properties via lit-html
+- [Dispatching Events](https://pionjs.com/guides/events/): Dispatch CustomEvents and listen for them on the element or up the DOM
+- [Virtual Components](https://pionjs.com/guides/virtual/): Stateful components without a custom element tag
+- [TypeScript](https://pionjs.com/guides/typescript/): Typing components, attributes, and HTMLElementTagNameMap
+
+## Hooks
+
+- [useState](https://pionjs.com/hooks/usestate/): Add reactive state; setter triggers re-render
+- [useEffect](https://pionjs.com/hooks/useeffect/): Side effects with dependency array and cleanup
+- [useReducer](https://pionjs.com/hooks/usereducer/): Reducer-based state management (redux-like)
+- [useContext](https://pionjs.com/hooks/usecontext/): Read values from the nearest context provider
+- [useRef](https://pionjs.com/hooks/useref/): Mutable value across renders without re-rendering; lit-html ref compatible
+- [useMemo](https://pionjs.com/hooks/usememo/): Memoize expensive computations by dependency
+- [useCallback](https://pionjs.com/hooks/usecallback/): Stable callback identity across renders
+- [useLayoutEffect](https://pionjs.com/hooks/uselayouteffect/): Synchronous effects before browser paint
+- [useHost](https://pionjs.com/hooks/usehost/): Access the host custom element instance
+- [useProperty](https://pionjs.com/hooks/useproperty/): State bound to a host property with change events
+
+## Optional
+
+- [GitHub repository](https://github.com/pionjs/pion): Source code, issues, and contributing guide
+- [npm package](https://www.npmjs.com/package/@pionjs/pion): Install with npm, yarn, or pnpm

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://pionjs.com/sitemap-index.xml

--- a/docs/src/components/Head.astro
+++ b/docs/src/components/Head.astro
@@ -2,4 +2,11 @@
 import Default from '@astrojs/starlight/components/Head.astro';
 ---
 <Default />
+<script is:inline type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: "pion",
+  url: "https://pionjs.com",
+  description: "Hooks for Web Components",
+})} />
 <script defer src="https://cloud.umami.is/script.js" data-website-id="8bd77f5a-a2da-4856-8963-3b95c7ce1302"></script>

--- a/docs/src/content/docs/guides/api.md
+++ b/docs/src/content/docs/guides/api.md
@@ -1,5 +1,6 @@
 ---
 title: API
+description: Reference for pion's component and virtual functions — write plain functions that hold state and return HTML.
 ---
 
 pion is all about writing plain functions that can contain their own state. The documentation below is separated into two sections: creating _components_ (the functions) and using _hooks_ to manage state.

--- a/docs/src/content/docs/guides/attributes.md
+++ b/docs/src/content/docs/guides/attributes.md
@@ -1,5 +1,6 @@
 ---
 title: Attributes
+description: Define observed attributes on your custom elements and pass string values from HTML using kebab-case names.
 ---
 
 In custom elements, attributes must be pre-defined. To define what attributes your component supports, set the `observedAttributes` property on the function you defined. Note that attributes use kebab case in templates and are converted into camel case for use in your component's code.

--- a/docs/src/content/docs/guides/events.md
+++ b/docs/src/content/docs/guides/events.md
@@ -1,5 +1,6 @@
 ---
 title: Dispatching Events
+description: Dispatch custom events from your pion custom elements and listen for them on the element or higher up in the DOM.
 ---
 
 There are a few steps you have to take in order to dispatch an event from your custom element:

--- a/docs/src/content/docs/guides/getting-started.mdx
+++ b/docs/src/content/docs/guides/getting-started.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting Started
+description: Install pion and build your first hook-powered Web Component with npm, yarn, or pnpm — works with or without a bundler.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/guides/index.mdx
+++ b/docs/src/content/docs/guides/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Guides
+description: Browse all pion guides — from getting started and renderers to attributes, properties, events, virtual components, and TypeScript.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/guides/index.mdx
+++ b/docs/src/content/docs/guides/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Guides
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <Card title="Getting Started" icon="rocket" href="/guides/getting-started/">
+    Install pion and write your first hook-powered Web Component.
+  </Card>
+  <Card title="Bring Your Own Renderer" icon="puzzle" href="/guides/renderers/">
+    Use your preferred templating library — Lit, htm, or a custom renderer.
+  </Card>
+  <Card title="Attributes" icon="settings" href="/guides/attributes/">
+    React to attribute changes on your custom elements.
+  </Card>
+  <Card title="Properties" icon="layers" href="/guides/properties/">
+    Manage reactive properties with type-safe accessors.
+  </Card>
+  <Card title="API" icon="code" href="/guides/api/">
+    Explore the full pion API reference.
+  </Card>
+  <Card title="Dispatching Events" icon="notification" href="/guides/events/">
+    Emit and listen to custom DOM events from hooks.
+  </Card>
+  <Card title="Virtual Components" icon="view-in-ar" href="/guides/virtual/">
+    Compose lightweight components without custom element registration.
+  </Card>
+  <Card title="TypeScript" icon="terminal" href="/guides/typescript/">
+    Get full type inference for hooks, props, and events.
+  </Card>
+</CardGrid>

--- a/docs/src/content/docs/guides/properties.md
+++ b/docs/src/content/docs/guides/properties.md
@@ -1,5 +1,6 @@
 ---
 title: Properties
+description: Bind to custom element properties with lit-html's dot syntax to pass values of any type beyond strings.
 ---
 
 If you haven't used lit-html before you're probably wondering what the differences between properties and attributes are. As stated above, attributes can only have string values, this is because all attributes go through [`Element#setAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute). Properties do not go through `setAttribute`, instead they are properties on the custom element itself. This allows you to pass in any value instead of just strings.

--- a/docs/src/content/docs/guides/renderers.md
+++ b/docs/src/content/docs/guides/renderers.md
@@ -1,5 +1,6 @@
 ---
 title: Bring Your Own Renderer
+description: Use pion with lighterhtml, hyperHTML, or any template library by importing the core build and wiring up your own render function.
 ---
 
 The main entry point is intended for [lit-html](https://github.com/Polymer/lit-html) users. If you are using [lighterhtml](https://github.com/WebReflection/lighterhtml) or [hyperHTML](https://github.com/WebReflection/hyperHTML) then instead import `@pionjs/pion/core`. This export gives you a function that creates Hooks that work with any template library.

--- a/docs/src/content/docs/guides/typescript.md
+++ b/docs/src/content/docs/guides/typescript.md
@@ -1,5 +1,6 @@
 ---
 title: TypeScript
+description: Type your pion components and custom elements in strict TypeScript projects — props, attributes, and tag name maps.
 ---
 
 pion is written in TypeScript and should work quite well with existing TS projects.

--- a/docs/src/content/docs/guides/virtual.md
+++ b/docs/src/content/docs/guides/virtual.md
@@ -1,5 +1,6 @@
 ---
 title: Virtual Components
+description: Create stateful components without a custom element tag using the virtual() helper, and compose them within other templates.
 ---
 
 pion also has the concept of _virtual components_. These are components that are not defined as a tag. Instead they're defined as functions that can be called from within another template. They have their own state and will rerender when that state changes _without_ causing any parent components to rerender.

--- a/docs/src/content/docs/hooks/index.mdx
+++ b/docs/src/content/docs/hooks/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Hooks
+description: Browse every pion hook — useState, useEffect, useReducer, useContext, useRef, useMemo, and more for building Web Components.
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/hooks/index.mdx
+++ b/docs/src/content/docs/hooks/index.mdx
@@ -1,0 +1,38 @@
+---
+title: Hooks
+---
+
+import { Card, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <Card title="useCallback" icon="repeat" href="/hooks/usecallback/">
+    Memoize a callback function to avoid unnecessary re-renders.
+  </Card>
+  <Card title="useContext" icon="share" href="/hooks/usecontext/">
+    Access shared context from parent components.
+  </Card>
+  <Card title="useEffect" icon="sync" href="/hooks/useeffect/">
+    Run side effects in response to state or prop changes.
+  </Card>
+  <Card title="useHost" icon="settings" href="/hooks/usehost/">
+    Access the host custom element instance.
+  </Card>
+  <Card title="useLayoutEffect" icon="speed" href="/hooks/uselayouteffect/">
+    Run side effects synchronously before the browser paints.
+  </Card>
+  <Card title="useMemo" icon="memory" href="/hooks/usememo/">
+    Cache expensive computations between renders.
+  </Card>
+  <Card title="useProperty" icon="layers" href="/hooks/useproperty/">
+    Create reactive properties with optional attribute reflection.
+  </Card>
+  <Card title="useReducer" icon="filter-list" href="/hooks/usereducer/">
+    Manage complex state with a reducer function.
+  </Card>
+  <Card title="useRef" icon="bookmark" href="/hooks/useref/">
+    Store a mutable value that persists across renders.
+  </Card>
+  <Card title="useState" icon="star" href="/hooks/usestate/">
+    Add reactive state to your Web Component.
+  </Card>
+</CardGrid>

--- a/docs/src/content/docs/hooks/usecallback.mdx
+++ b/docs/src/content/docs/hooks/usecallback.mdx
@@ -1,5 +1,6 @@
 ---
 title: useCallback
+description: Memoize a callback so it keeps the same identity across renders unless its dependencies change — ideal for stable handlers passed to useEffect.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/usecontext.mdx
+++ b/docs/src/content/docs/hooks/usecontext.mdx
@@ -1,5 +1,6 @@
 ---
 title: useContext
+description: Read a value from the nearest context provider and re-render your component whenever the provider's value changes.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/useeffect.mdx
+++ b/docs/src/content/docs/hooks/useeffect.mdx
@@ -1,5 +1,6 @@
 ---
 title: useEffect
+description: Run side effects after render, with optional dependencies and a cleanup function for tearing down listeners and subscriptions.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/usehost.mdx
+++ b/docs/src/content/docs/hooks/usehost.mdx
@@ -1,5 +1,6 @@
 ---
 title: useHost
+description: Access the host custom element instance from within your component — useful for third-party integration and host-specific APIs.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/uselayouteffect.mdx
+++ b/docs/src/content/docs/hooks/uselayouteffect.mdx
@@ -1,5 +1,6 @@
 ---
 title: useLayoutEffect
+description: Run side effects synchronously after render but before the browser paints — for measuring layout or reading DOM geometry.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/usememo.mdx
+++ b/docs/src/content/docs/hooks/usememo.mdx
@@ -1,5 +1,6 @@
 ---
 title: useMemo
+description: Cache an expensive computation and only recompute when its dependencies change, avoiding redundant work on every render.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/useproperty.mdx
+++ b/docs/src/content/docs/hooks/useproperty.mdx
@@ -1,5 +1,6 @@
 ---
 title: useProperty
+description: Bind state to a host element property and dispatch {property}-changed events so parents can override or react to changes.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/usereducer.mdx
+++ b/docs/src/content/docs/hooks/usereducer.mdx
@@ -1,5 +1,6 @@
 ---
 title: useReducer
+description: Manage complex state with a reducer function and dispatch actions — a redux-like pattern for stateful Web Components.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/useref.mdx
+++ b/docs/src/content/docs/hooks/useref.mdx
@@ -1,5 +1,6 @@
 ---
 title: useRef
+description: Hold a mutable value across renders without triggering re-renders — also compatible with lit-html's ref directive.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/docs/src/content/docs/hooks/usestate.mdx
+++ b/docs/src/content/docs/hooks/usestate.mdx
@@ -1,5 +1,6 @@
 ---
 title: useState
+description: Add reactive state to your component; calling the setter re-renders the element with the new immutable value.
 ---
 
 import ApiDoc from '../../../components/ApiDoc.astro';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pionjs/pion",
   "version": "2.16.1",
-  "description": "Hooks for web components",
+  "description": "Hooks for Web Components — React's hooks API for custom elements, works with lit-html or any renderer",
   "main": "lib/haunted.js",
   "module": "lib/haunted.js",
   "type": "module",
@@ -22,9 +22,14 @@
     "url": "git+https://github.com/pionjs/pion.git"
   },
   "keywords": [
+    "pion",
     "haunted",
     "lit",
-    "web-components"
+    "lit-html",
+    "web-components",
+    "custom-elements",
+    "hooks",
+    "react-hooks"
   ],
   "author": "",
   "license": "BSD-2-Clause",

--- a/readme.md
+++ b/readme.md
@@ -41,14 +41,16 @@ pion supports the same API as React Hooks. The hope is that by doing so you can 
 
 Currently pion supports the following hooks:
 
-- [useCallback](https://pionjs.com/docs/hooks/useCallback/)
-- [useContext](https://pionjs.com/docs/hooks/useContext/)
-- [useEffect](https://pionjs.com/docs/hooks/useEffect/)
-- [useLayoutEffect](https://pionjs.com/docs/hooks/useLayoutEffect/)
-- [useMemo](https://pionjs.com/docs/hooks/useMemo/)
-- [useReducer](https://pionjs.com/docs/hooks/useReducer/)
-- [useRef](https://pionjs.com/docs/hooks/useRef/)
-- [useState](https://pionjs.com/docs/hooks/useState/)
+- [useCallback](https://pionjs.com/hooks/usecallback/)
+- [useContext](https://pionjs.com/hooks/usecontext/)
+- [useEffect](https://pionjs.com/hooks/useeffect/)
+- [useHost](https://pionjs.com/hooks/usehost/)
+- [useLayoutEffect](https://pionjs.com/hooks/uselayouteffect/)
+- [useMemo](https://pionjs.com/hooks/usememo/)
+- [useProperty](https://pionjs.com/hooks/useproperty/)
+- [useReducer](https://pionjs.com/hooks/usereducer/)
+- [useRef](https://pionjs.com/hooks/useref/)
+- [useState](https://pionjs.com/hooks/usestate/)
 
 ### Function Signatures
 


### PR DESCRIPTION
## What changed

### Redirects & index pages (commit 1)
- **Sitemap domain**: `site` updated from `pionjs.github.io/pion` to `pionjs.com` so Google sees the correct canonical URLs
- **Group index pages**: Created `/guides/` and `/hooks/` index pages with card grids listing all entries
- **Old URL redirects**: Added Netlify `_redirects` file to 301-redirect legacy `/docs/`-prefixed URLs to their current paths
- **Sidebar UX**: Made Guides and Hooks groups start collapsed

### SEO metadata (commit 2)
- **Page descriptions**: Added `description` frontmatter to all 20 content pages so Starlight renders `og:description` and `meta name=description` tags (previously only the splash page had a description)
- **robots.txt**: Created with `Allow: /` and sitemap reference at `https://pionjs.com/sitemap-index.xml`
- **Structured data**: Inject `WebSite` JSON-LD schema globally via `Head.astro`
- **Logo alt text**: Set to `'pion'` (was empty string)

### LLM / GEO optimization (commit 3)
- **llms.txt**: Created curated `/llms.txt` following the [llms-txt spec](https://llmstxt.org/) — a concise positioning summary plus links to all guides and hooks, so LLMs can load pion context in a single fetch and recommend it for the hooks + Web Components use case
- **README links**: Fixed 8 broken hook links (old `/docs/` prefix + wrong casing) and added missing `useHost` and `useProperty` entries — the README is the primary content LLMs ingest from GitHub, so broken links actively harmed understanding
- **package.json metadata**: Improved `description` to mention the React-hooks connection, and added keywords (`pion`, `hooks`, `react-hooks`, `custom-elements`, `lit-html`) for better npm discovery and LLM categorization

## Why

Google Search Console reported 14 404 errors — all from old `/docs/`-prefixed URLs that predate the Starlight migration. A full SEO audit also revealed missing `og:description` tags on content pages, no `robots.txt`, no structured data, and an empty logo `alt` attribute. Beyond traditional SEO, the project was also not optimized for LLM discovery (no `llms.txt`, broken README links, weak npm keywords).

## Resolved 404s

| Old URL (404) | New URL (200) |
|---|---|
| `/docs/` | `/` (301) |
| `/docs/guides/` | `/guides/` (301, now has index page) |
| `/docs/guides/\*` | `/guides/\*` (301) |
| `/docs/hooks/\*` | `/hooks/\*` (301) |

## Verification

- `npm run build --prefix docs` succeeds (22 pages)
- `og:description` present on content pages ✓
- JSON-LD `WebSite` schema present on all pages ✓
- `robots.txt` in dist with sitemap reference ✓
- `llms.txt` in dist at root ✓
- Logo `alt="pion"` ✓
- Sitemap uses `https://pionjs.com` ✓

## Files

| File | Change |
|---|---|
| `docs/astro.config.mjs` | Fixed `site`, added `collapsed` to sidebar groups, logo `alt` |
| `docs/public/_redirects` | New — Netlify redirect rules for old `/docs/` prefix |
| `docs/public/robots.txt` | New — robots rules + sitemap reference |
| `docs/public/llms.txt` | New — LLM-friendly summary + links to all docs |
| `docs/src/components/Head.astro` | Added `WebSite` JSON-LD structured data |
| `docs/src/content/docs/guides/index.mdx` | New — card grid for all guides |
| `docs/src/content/docs/hooks/index.mdx` | New — card grid for all hooks |
| `docs/src/content/docs/guides/*.md*` (8) | Added `description` frontmatter |
| `docs/src/content/docs/hooks/*.mdx` (10) | Added `description` frontmatter |
| `readme.md` | Fixed 8 broken hook links, added useHost + useProperty |
| `package.json` | Improved description + added keywords |