### PR TITLE
fix(ci): use renamed changesets/action v2 inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,8 +133,7 @@ jobs:
         id: changesets
         uses: changesets/action@v2
         with:
-          publish: npm run changeset publish
-          commit: "[ci] release"
-          title: "[ci] release"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          publish-script: npm run changeset publish
+          commit-message: "[ci] release"
+          pr-title: "[ci] release"
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Fixes the failing `Changelog PR or Release` job on `main` (broken since #177 bumped `changesets/action` from v1 to v2).

v2 renamed its inputs and hard-fails on the old names:
- `publish` → `publish-script`
- `commit` → `commit-message`
- `title` → `pr-title`

Also passes the token via the `github-token` input, since v2 no longer reads `GITHUB_TOKEN` from the environment.